### PR TITLE
fix build issues with rocksdb v7

### DIFF
--- a/db.go
+++ b/db.go
@@ -91,12 +91,12 @@ func OpenDbForReadOnly(opts *Options, name string, errorIfLogFileExist bool) (*D
 // OpenDbAsSecondary opens a database with the specified options as secondary instance.
 func OpenDbAsSecondary(opts *Options, name string, secondaryPath string) (*DB, error) {
 	var (
-		cErr          *C.char
-		cName         = C.CString(name)
-		cSeconrayPath = C.CString(secondaryPath)
+		cErr           *C.char
+		cName          = C.CString(name)
+		cSecondaryPath = C.CString(secondaryPath)
 	)
 	defer C.free(unsafe.Pointer(cName))
-	defer C.free(unsafe.Pointer(&cSeconrayPath))
+	defer C.free(unsafe.Pointer(&cSecondaryPath))
 	db := C.rocksdb_open_as_secondary(opts.c, cName, cSecondaryPath, &cErr)
 	if cErr != nil {
 		defer C.rocksdb_free(unsafe.Pointer(cErr))
@@ -241,7 +241,6 @@ func OpenDbAsSecondaryColumnFamilies(
 	secondaryPath string,
 	cfNames []string,
 	cfOpts []*Options,
-	errorIfLogFileExist bool,
 ) (*DB, []*ColumnFamilyHandle, error) {
 	numColumnFamilies := len(cfNames)
 	if numColumnFamilies != len(cfOpts) {
@@ -280,7 +279,6 @@ func OpenDbAsSecondaryColumnFamilies(
 		&cNames[0],
 		&cOpts[0],
 		&cHandles[0],
-		boolToChar(errorIfLogFileExist),
 		&cErr,
 	)
 	if cErr != nil {

--- a/filter_policy.go
+++ b/filter_policy.go
@@ -3,26 +3,8 @@ package gorocksdb
 // #include "rocksdb/c.h"
 import "C"
 
-// FilterPolicy is a factory type that allows the RocksDB database to create a
-// filter, such as a bloom filter, which will used to reduce reads.
-type FilterPolicy interface {
-	// keys contains a list of keys (potentially with duplicates)
-	// that are ordered according to the user supplied comparator.
-	CreateFilter(keys [][]byte) []byte
-
-	// "filter" contains the data appended by a preceding call to
-	// CreateFilter(). This method must return true if
-	// the key was in the list of keys passed to CreateFilter().
-	// This method may return true or false if the key was not on the
-	// list, but it should aim to return false with a high probability.
-	KeyMayMatch(key []byte, filter []byte) bool
-
-	// Return the name of this policy.
-	Name() string
-}
-
-// NewNativeFilterPolicy creates a FilterPolicy object.
-func NewNativeFilterPolicy(c *C.rocksdb_filterpolicy_t) FilterPolicy {
+// NewNativeFilterPolicy creates a nativeFilterPolicy object.
+func NewNativeFilterPolicy(c *C.rocksdb_filterpolicy_t) nativeFilterPolicy {
 	return nativeFilterPolicy{c}
 }
 
@@ -45,50 +27,12 @@ func (fp nativeFilterPolicy) Name() string                               { retur
 // ignores trailing spaces, it would be incorrect to use a
 // FilterPolicy (like NewBloomFilterPolicy) that does not ignore
 // trailing spaces in keys.
-func NewBloomFilter(bitsPerKey int) FilterPolicy {
+func NewBloomFilter(bitsPerKey int) nativeFilterPolicy {
 	return NewNativeFilterPolicy(C.rocksdb_filterpolicy_create_bloom(C.double(bitsPerKey)))
 }
 
 // NewBloomFilterFull returns a new filter policy created with use_block_based_builder=false
 // (use full or partitioned filter).
-func NewBloomFilterFull(bitsPerKey int) FilterPolicy {
+func NewBloomFilterFull(bitsPerKey int) nativeFilterPolicy {
 	return NewNativeFilterPolicy(C.rocksdb_filterpolicy_create_bloom_full(C.double(bitsPerKey)))
-}
-
-// Hold references to filter policies.
-var filterPolicies = NewCOWList()
-
-type filterPolicyWrapper struct {
-	name         *C.char
-	filterPolicy FilterPolicy
-}
-
-func registerFilterPolicy(fp FilterPolicy) int {
-	return filterPolicies.Append(filterPolicyWrapper{C.CString(fp.Name()), fp})
-}
-
-//export gorocksdb_filterpolicy_create_filter
-func gorocksdb_filterpolicy_create_filter(idx int, cKeys **C.char, cKeysLen *C.size_t, cNumKeys C.int, cDstLen *C.size_t) *C.char {
-	rawKeys := charSlice(cKeys, cNumKeys)
-	keysLen := sizeSlice(cKeysLen, cNumKeys)
-	keys := make([][]byte, int(cNumKeys))
-	for i, len := range keysLen {
-		keys[i] = charToByte(rawKeys[i], len)
-	}
-
-	dst := filterPolicies.Get(idx).(filterPolicyWrapper).filterPolicy.CreateFilter(keys)
-	*cDstLen = C.size_t(len(dst))
-	return cByteSlice(dst)
-}
-
-//export gorocksdb_filterpolicy_key_may_match
-func gorocksdb_filterpolicy_key_may_match(idx int, cKey *C.char, cKeyLen C.size_t, cFilter *C.char, cFilterLen C.size_t) C.uchar {
-	key := charToByte(cKey, cKeyLen)
-	filter := charToByte(cFilter, cFilterLen)
-	return boolToChar(filterPolicies.Get(idx).(filterPolicyWrapper).filterPolicy.KeyMayMatch(key, filter))
-}
-
-//export gorocksdb_filterpolicy_name
-func gorocksdb_filterpolicy_name(idx int) *C.char {
-	return filterPolicies.Get(idx).(filterPolicyWrapper).name
 }

--- a/filter_policy.go
+++ b/filter_policy.go
@@ -36,3 +36,16 @@ func NewBloomFilter(bitsPerKey int) nativeFilterPolicy {
 func NewBloomFilterFull(bitsPerKey int) nativeFilterPolicy {
 	return NewNativeFilterPolicy(C.rocksdb_filterpolicy_create_bloom_full(C.double(bitsPerKey)))
 }
+
+// NewRibbonFilter returns a new filter policy that uses a ribbon filter with approximately
+// the specified number of bits per key.  A good value for bits_per_key
+// is 9.9, which yields a filter with ~1% false positive rate.
+func NewRibbonFilter(bloomEquivalentBitsPerKey float64) nativeFilterPolicy {
+	return NewNativeFilterPolicy(C.rocksdb_filterpolicy_create_ribbon(C.double(bloomEquivalentBitsPerKey)))
+}
+
+// NewRibbonHybridFilter returns a new filter policy that use both bloom and ribbon filters,
+// bloom filters are used for top levels while ribbon filters are used for lower ones.
+func NewRibbonHybridFilter(bloomEquivalentBitsPerKey float64, bloomBeforeLevel int) nativeFilterPolicy {
+	return NewNativeFilterPolicy(C.rocksdb_filterpolicy_create_ribbon_hybrid(C.double(bloomEquivalentBitsPerKey), C.int(bloomBeforeLevel)))
+}

--- a/gorocksdb.c
+++ b/gorocksdb.c
@@ -25,22 +25,6 @@ rocksdb_compactionfilter_t* gorocksdb_compactionfilter_create(uintptr_t idx) {
         (const char *(*)(void*))(gorocksdb_compactionfilter_name));
 }
 
-/* Filter Policy */
-
-rocksdb_filterpolicy_t* gorocksdb_filterpolicy_create(uintptr_t idx) {
-    return rocksdb_filterpolicy_create(
-        (void*)idx,
-        gorocksdb_destruct_handler,
-        (char* (*)(void*, const char* const*, const size_t*, int, size_t*))(gorocksdb_filterpolicy_create_filter),
-        (unsigned char (*)(void*, const char*, size_t, const char*, size_t))(gorocksdb_filterpolicy_key_may_match),
-        gorocksdb_filterpolicy_delete_filter,
-        (const char *(*)(void*))(gorocksdb_filterpolicy_name));
-}
-
-void gorocksdb_filterpolicy_delete_filter(void* state, const char* v, size_t s) {
-    free((char*)v);
-}
-
 /* Merge Operator */
 
 rocksdb_mergeoperator_t* gorocksdb_mergeoperator_create(uintptr_t idx) {

--- a/gorocksdb.h
+++ b/gorocksdb.h
@@ -15,11 +15,6 @@ extern rocksdb_compactionfilter_t* gorocksdb_compactionfilter_create(uintptr_t i
 
 extern rocksdb_comparator_t* gorocksdb_comparator_create(uintptr_t idx);
 
-/* Filter Policy */
-
-extern rocksdb_filterpolicy_t* gorocksdb_filterpolicy_create(uintptr_t idx);
-extern void gorocksdb_filterpolicy_delete_filter(void* state, const char* v, size_t s);
-
 /* Merge Operator */
 
 extern rocksdb_mergeoperator_t* gorocksdb_mergeoperator_create(uintptr_t idx);

--- a/options.go
+++ b/options.go
@@ -434,6 +434,11 @@ func (opts *Options) SetCompressionOptions(value *CompressionOptions) {
 	C.rocksdb_options_set_compression_options(opts.c, C.int(value.WindowBits), C.int(value.Level), C.int(value.Strategy), C.int(value.MaxDictBytes))
 }
 
+func (opts *Options) SetZSTDCompressionOptions(value *ZSTDCompressionOptions) {
+	C.rocksdb_options_set_compression_options_use_zstd_dict_trainer(opts.c, C.uchar(value.UseDictTrainer))
+	C.rocksdb_options_set_compression_options_zstd_max_train_bytes(opts.c, C.int(value.MaxTrainBytes))
+}
+
 // SetPrefixExtractor sets the prefic extractor.
 //
 // If set, use the specified function to determine the
@@ -483,19 +488,6 @@ func (opts *Options) SetLevel0SlowdownWritesTrigger(value int) {
 // Default: 12
 func (opts *Options) SetLevel0StopWritesTrigger(value int) {
 	C.rocksdb_options_set_level0_stop_writes_trigger(opts.c, C.int(value))
-}
-
-// SetMaxMemCompactionLevel sets the maximum level
-// to which a new compacted memtable is pushed if it does not create overlap.
-//
-// We try to push to level 2 to avoid the
-// relatively expensive level 0=>1 compactions and to avoid some
-// expensive manifest file operations. We do not push all the way to
-// the largest level since that can generate a lot of wasted disk
-// space if the same key space is being repeatedly overwritten.
-// Default: 2
-func (opts *Options) SetMaxMemCompactionLevel(value int) {
-	C.rocksdb_options_set_max_mem_compaction_level(opts.c, C.int(value))
 }
 
 // SetTargetFileSizeBase sets the target file size for compaction.
@@ -739,34 +731,6 @@ func (opts *Options) SetKeepLogFileNum(value int) {
 	C.rocksdb_options_set_keep_log_file_num(opts.c, C.size_t(value))
 }
 
-// SetSoftRateLimit sets the soft rate limit.
-//
-// Puts are delayed 0-1 ms when any level has a compaction score that exceeds
-// soft_rate_limit. This is ignored when == 0.0.
-// CONSTRAINT: soft_rate_limit <= hard_rate_limit. If this constraint does not
-// hold, RocksDB will set soft_rate_limit = hard_rate_limit
-// Default: 0.0 (disabled)
-func (opts *Options) SetSoftRateLimit(value float64) {
-	C.rocksdb_options_set_soft_rate_limit(opts.c, C.double(value))
-}
-
-// SetHardRateLimit sets the hard rate limit.
-//
-// Puts are delayed 1ms at a time when any level has a compaction score that
-// exceeds hard_rate_limit. This is ignored when <= 1.0.
-// Default: 0.0 (disabled)
-func (opts *Options) SetHardRateLimit(value float64) {
-	C.rocksdb_options_set_hard_rate_limit(opts.c, C.double(value))
-}
-
-// SetRateLimitDelayMaxMilliseconds sets the max time
-// a put will be stalled when hard_rate_limit is enforced.
-// If 0, then there is no limit.
-// Default: 1000
-func (opts *Options) SetRateLimitDelayMaxMilliseconds(value uint) {
-	C.rocksdb_options_set_rate_limit_delay_max_milliseconds(opts.c, C.uint(value))
-}
-
 // SetMaxManifestFileSize sets the maximal manifest file size until is rolled over.
 // The older manifest file be deleted.
 // Default: MAX_INT so that roll-over does not take place.
@@ -778,19 +742,6 @@ func (opts *Options) SetMaxManifestFileSize(value uint64) {
 // Default: 4
 func (opts *Options) SetTableCacheNumshardbits(value int) {
 	C.rocksdb_options_set_table_cache_numshardbits(opts.c, C.int(value))
-}
-
-// SetTableCacheRemoveScanCountLimit sets the count limit during a scan.
-//
-// During data eviction of table's LRU cache, it would be inefficient
-// to strictly follow LRU because this piece of memory will not really
-// be released unless its refcount falls to zero. Instead, make two
-// passes: the first pass will release items with refcount = 1,
-// and if not enough space releases after scanning the number of
-// elements specified by this parameter, we will remove items in LRU order.
-// Default: 16
-func (opts *Options) SetTableCacheRemoveScanCountLimit(value int) {
-	C.rocksdb_options_set_table_cache_remove_scan_count_limit(opts.c, C.int(value))
 }
 
 // SetArenaBlockSize sets the size of one block in arena memory allocation.
@@ -864,13 +815,6 @@ func (opts *Options) SetManifestPreallocationSize(value int) {
 	C.rocksdb_options_set_manifest_preallocation_size(opts.c, C.size_t(value))
 }
 
-// SetPurgeRedundantKvsWhileFlush enable/disable purging of
-// duplicate/deleted keys when a memtable is flushed to storage.
-// Default: true
-func (opts *Options) SetPurgeRedundantKvsWhileFlush(value bool) {
-	C.rocksdb_options_set_purge_redundant_kvs_while_flush(opts.c, boolToChar(value))
-}
-
 // SetAllowMmapReads enable/disable mmap reads for reading sst tables.
 // Default: false
 func (opts *Options) SetAllowMmapReads(value bool) {
@@ -900,14 +844,6 @@ func (opts *Options) SetUseDirectIOForFlushAndCompaction(value bool) {
 // Default: true
 func (opts *Options) SetIsFdCloseOnExec(value bool) {
 	C.rocksdb_options_set_is_fd_close_on_exec(opts.c, boolToChar(value))
-}
-
-// SetSkipLogErrorOnRecovery enable/disable skipping of
-// log corruption error on recovery (If client is ok with
-// losing most recent changes)
-// Default: false
-func (opts *Options) SetSkipLogErrorOnRecovery(value bool) {
-	C.rocksdb_options_set_skip_log_error_on_recovery(opts.c, boolToChar(value))
 }
 
 // SetStatsDumpPeriodSec sets the stats dump period in seconds.

--- a/options_block_based_table.go
+++ b/options_block_based_table.go
@@ -138,12 +138,6 @@ func (opts *BlockBasedTableOptions) SetPartitionFilters(value bool) {
 	C.rocksdb_block_based_options_set_partition_filters(opts.c, boolToChar(value))
 }
 
-// SetOptimizeFiltersForMemory sets the option to generate Bloom/Ribbon filters that minimize memory
-// internal fragmentation.
-func (opts *BlockBasedTableOptions) SetOptimizeFiltersForMemory(value bool) {
-	C.rocksdb_block_based_options_set_optimize_filters_for_memory(opts.c, boolToChar(value))
-}
-
 // SetUseDeltaEncoding sets using delta encoding to compress keys in blocks.
 // ReadOptions::pin_data requires this option to be disabled.
 func (opts *BlockBasedTableOptions) SetUseDeltaEncoding(value bool) {

--- a/options_block_based_table.go
+++ b/options_block_based_table.go
@@ -138,6 +138,12 @@ func (opts *BlockBasedTableOptions) SetPartitionFilters(value bool) {
 	C.rocksdb_block_based_options_set_partition_filters(opts.c, boolToChar(value))
 }
 
+// SetOptimizeFiltersForMemory sets the option to generate Bloom/Ribbon filters that minimize memory
+// internal fragmentation.
+func (opts *BlockBasedTableOptions) SetOptimizeFiltersForMemory(value bool) {
+	C.rocksdb_block_based_options_set_optimize_filters_for_memory(opts.c, boolToChar(value))
+}
+
 // SetUseDeltaEncoding sets using delta encoding to compress keys in blocks.
 // ReadOptions::pin_data requires this option to be disabled.
 func (opts *BlockBasedTableOptions) SetUseDeltaEncoding(value bool) {

--- a/options_block_based_table.go
+++ b/options_block_based_table.go
@@ -7,6 +7,9 @@ import "C"
 // IndexType specifies the index type that will be used for this table.
 type IndexType uint
 
+// DataBlockIndexType specifies the index type that will be used for the data block.
+type DataBlockIndexType uint
+
 const (
 	// A space efficient index block that is optimized for
 	// binary-search-based index.
@@ -16,6 +19,11 @@ const (
 	KHashSearchIndexType = 1
 	// A two-level index implementation. Both levels are binary search indexes.
 	KTwoLevelIndexSearchIndexType = 2
+
+	// traditional block type
+	KDataBlockBinarySearch = 0
+	// additional hash index
+	KDataBlockBinaryAndHash = 1
 )
 
 // BlockBasedTableOptions represents block-based table options.
@@ -229,4 +237,15 @@ func (opts *BlockBasedTableOptions) SetFormatVersion(version int) {
 // Default: kBinarySearch
 func (opts *BlockBasedTableOptions) SetIndexType(value IndexType) {
 	C.rocksdb_block_based_options_set_index_type(opts.c, C.int(value))
+}
+
+// SetDataBlockIndexType specifies the index type that will be used for the data block.
+func (opts *BlockBasedTableOptions) SetDataBlockIndexType(value DataBlockIndexType) {
+	C.rocksdb_block_based_options_set_data_block_index_type(opts.c, C.int(value))
+}
+
+// SetDataBlockHashRatio specifies the #entries/#buckets. It is valid only when data_block_hash_index_type is
+// kDataBlockBinaryAndHash.
+func (opts *BlockBasedTableOptions) SetDataBlockHashRatio(value float64) {
+	C.rocksdb_block_based_options_set_data_block_hash_ratio(opts.c, C.double(value))
 }

--- a/options_block_based_table.go
+++ b/options_block_based_table.go
@@ -148,13 +148,8 @@ func (opts *BlockBasedTableOptions) SetUseDeltaEncoding(value bool) {
 // Many applications will benefit from passing the result of
 // NewBloomFilterPolicy() here.
 // Default: nil
-func (opts *BlockBasedTableOptions) SetFilterPolicy(fp FilterPolicy) {
-	if nfp, ok := fp.(nativeFilterPolicy); ok {
-		opts.cFp = nfp.c
-	} else {
-		idx := registerFilterPolicy(fp)
-		opts.cFp = C.gorocksdb_filterpolicy_create(C.uintptr_t(idx))
-	}
+func (opts *BlockBasedTableOptions) SetFilterPolicy(nfp nativeFilterPolicy) {
+	opts.cFp = nfp.c
 	C.rocksdb_block_based_options_set_filter_policy(opts.c, opts.cFp)
 }
 

--- a/options_compression.go
+++ b/options_compression.go
@@ -22,3 +22,15 @@ func NewCompressionOptions(windowBits, level, strategy, maxDictBytes int) *Compr
 		MaxDictBytes: maxDictBytes,
 	}
 }
+
+type ZSTDCompressionOptions struct {
+	UseDictTrainer int8
+	MaxTrainBytes  int
+}
+
+func NewZSTDCompressionOptions(useDictTrainer int8, maxTrainBytes int) *ZSTDCompressionOptions {
+	return &ZSTDCompressionOptions{
+		UseDictTrainer: useDictTrainer,
+		MaxTrainBytes:  maxTrainBytes,
+	}
+}


### PR DESCRIPTION
Solution:
- remove custom filterpolicy support, due to drop of api `rocksdb_filterpolicy_create`.

rocksdb v7 support zstd dictionary compression, and serious compaction improvements[^1]

[^1]: https://github.com/crypto-org-chain/cronos/issues/759